### PR TITLE
fix: Run poetry install after disabling virtual environment

### DIFF
--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -3,18 +3,20 @@ FROM python:3.13.0
 RUN mkdir -p /src
 WORKDIR /src
 
-COPY ./pyproject.toml ./poetry.lock /src/
 
 RUN python -m pip install --upgrade pip
 RUN apt-get update
 RUN apt-get install -y libsqlite3-dev
+
 RUN pip install poetry
 
-
-# RUN poetry install --no-root
-
 # OFF virtual envs of poetry
+# you should off the envs of poetry before `poerty install`
 RUN poetry config virtualenvs.create false
 RUN poetry config virtualenvs.in-project false
+
+COPY ./pyproject.toml ./poetry.lock /src/
+RUN poetry install --no-root
+
 
 RUN if [ -f pyproject.toml ]; then poetry install --no-root; else exit 1; fi


### PR DESCRIPTION
This change ensures that dependencies are installed globally rather than within a virtual environment, which is disabled by the configuration. By running poetry install after turning off virtual environments, it guarantees that all dependencies are available directly in the system's environment, avoiding issues where dependencies might only be accessible within a specific virtual environment.
Then you can run `pytest` as you expected.